### PR TITLE
Fix typo in landingapp Dockerfile

### DIFF
--- a/src/components/landingapp/Dockerfile
+++ b/src/components/landingapp/Dockerfile
@@ -1,4 +1,4 @@
-# Offcial node image
+# Official node image
 FROM node:18-alpine
 
 # Create a working directory


### PR DESCRIPTION
## Summary
- fix official comment typo in `landingapp` Dockerfile

## Testing
- `tail -n 5 src/components/landingapp/Dockerfile | cat -n`

------
https://chatgpt.com/codex/tasks/task_e_6842c0e5dff48325b1295e62db1eebce